### PR TITLE
feat: add code size analyzer

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,6 @@
 import type { ObfuscatorOptions } from 'javascript-obfuscator';
 import type { Plugin, Rollup } from 'vite';
+import { SizeUnit } from './utils/constants';
 
 export type ViteConfigFn = Plugin['config'];
 
@@ -8,6 +9,13 @@ export type BundleList = Array<[string, Rollup.OutputChunk]>;
 export interface WorkerMessage {
   config: Config;
   chunk: BundleList;
+}
+
+export type SizeResult = { original: FormatSizeResult; gzip: FormatSizeResult };
+
+export interface FormatSizeResult {
+  value: number;
+  unit: SizeUnit;
 }
 
 export interface ObfuscationResult {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -44,7 +44,14 @@ export const VENDOR_MODULES = 'vendor-modules';
 
 export const CHUNK_PREFIX = 'vendor-';
 
+export enum SizeUnit {
+  B = 'B',
+  KB = 'KB',
+  MB = 'MB',
+}
+
 export const LOG_COLOR = Object.freeze({
   info: '\x1b[36m', // Cyan
   warn: '\x1b[33m', // Yellow
+  success: '\x1b[32m', // Green
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -186,7 +186,7 @@ export class CodeSizeAnalyzer {
     const { totalSize, gzipSize } = bundleList.reduce(
       (acc, [, bundleItem]) => {
         if (bundleItem.code) {
-          const code = bundleItem.code;
+          const { code } = bundleItem;
           acc.totalSize += Buffer.byteLength(code, 'utf-8');
           acc.gzipSize += gzipSync(code, { level: 9 }).byteLength;
         }


### PR DESCRIPTION
## Summary by Sourcery

Add a code size analyzer to measure and log the size of code bundles before and after obfuscation, including gzip sizes. Enhance the logging of the obfuscation process with detailed size information.

New Features:
- Introduce a CodeSizeAnalyzer class to measure and log the size of code bundles before and after obfuscation, including gzip sizes.

Enhancements:
- Add a formatSize function to convert byte sizes into human-readable formats with appropriate units.