### PR TITLE
docs: update logo image URL in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img height="160" src="https://www.obfuscator.io/static/images/logo.png" alt="vite-plugin-bundle-obfuscator logo" />
+<img height="160" src="https://obfuscator.io/images/logo.png" alt="vite-plugin-bundle-obfuscator logo" />
 
 # vite-plugin-bundle-obfuscator
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img height="160" src="https://www.obfuscator.io/static/images/logo.png" alt="vite-plugin-bundle-obfuscator logo" />
+<img height="160" src="https://obfuscator.io/images/logo.png" alt="vite-plugin-bundle-obfuscator logo" />
 
 # vite-plugin-bundle-obfuscator
 


### PR DESCRIPTION
- Update the logo image URL in both README.md and README.zh-CN.md
- Change the URL from 'https://www.obfuscator.io/static/images/logo.png' to 'https://obfuscator.io/images/logo.png'

## Summary by Sourcery

Documentation:
- Update the logo image URL in both README.md and README.zh-CN.md.