### PR TITLE
feat: enhance obfuscation process with registry management

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -9,6 +9,12 @@ export type BundleList = Array<[string, Rollup.OutputChunk]>;
 export interface WorkerMessage {
   config: Config;
   chunk: BundleList;
+  registryState?: string[];
+}
+
+export interface WorkerResponse {
+  results: ObfuscationResult[];
+  registryState: string[];
 }
 
 export type SizeResult = { original: FormatSizeResult; gzip: FormatSizeResult };

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -23,13 +23,23 @@ export function isBoolean(input: any): input is boolean {
   return Object.prototype.toString.call(input) === '[object Boolean]';
 }
 
-export function isFileNameExcluded(name: string, excludes: (RegExp | string)[]): boolean {
-  for (const exclude of excludes) {
-    if (isRegExp(exclude)) {
-      if (exclude.test(name)) return true;
-    } else if (isString(exclude)) {
-      if (name.includes(exclude)) return true;
-    }
+export function isFileNameExcluded(fileName: string, excludes: (RegExp | string)[] | RegExp | string): boolean {
+  if (!excludes) return false;
+
+  if (Array.isArray(excludes)) {
+    return excludes.some((exclude) => {
+      if (isString(exclude)) {
+        return fileName.includes(exclude);
+      } else if (isRegExp(exclude)) {
+        return exclude.test(fileName);
+      }
+      return false;
+    });
+  } else if (isString(excludes)) {
+    return fileName.includes(excludes);
+  } else if (isRegExp(excludes)) {
+    return excludes.test(fileName);
   }
+
   return false;
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,15 +1,46 @@
 import { parentPort } from 'node:worker_threads';
-import { ObfuscationResult, WorkerMessage } from '../type';
-import { obfuscateBundle } from '../utils';
+import javascriptObfuscator from 'javascript-obfuscator';
+import { Log, ObfuscatedFilesRegistry } from '../utils';
+import type { ObfuscationResult, WorkerMessage } from '../type';
 
-parentPort?.on('message', (message: WorkerMessage) => {
-  const { config, chunk } = message;
+if (parentPort) {
+  parentPort.on('message', (message: WorkerMessage) => {
+    const results: ObfuscationResult[] = [];
+    const _log = new Log(message.config.log);
+    const registry = ObfuscatedFilesRegistry.getInstance();
 
-  const result: ObfuscationResult[] = chunk.map(([fileName, bundleItem]) => {
-    const obfuscatedCode = obfuscateBundle(config, fileName, bundleItem);
+    if (message.registryState && Array.isArray(message.registryState)) {
+      registry.updateFromSerialized(message.registryState);
+    }
 
-    return { fileName, obfuscatedCode };
+    for (const [fileName, bundleItem] of message.chunk) {
+      if (registry.isObfuscated(fileName)) {
+        _log.info(`skipping ${fileName} (already in obfuscated registry)`);
+        results.push({
+          fileName,
+          obfuscatedCode: bundleItem.code,
+        });
+        continue;
+      }
+
+      _log.info(`worker obfuscating ${fileName}...`);
+      const obfuscated = javascriptObfuscator.obfuscate(bundleItem.code, message.config.options);
+      _log.info(`worker obfuscation complete for ${fileName}.`);
+
+      registry.markAsObfuscated(fileName);
+      _log.info(`worker added ${fileName} to obfuscated files registry`);
+
+      results.push({
+        fileName,
+        obfuscatedCode: obfuscated.getObfuscatedCode(),
+      });
+    }
+
+    if (parentPort) {
+      parentPort.postMessage({
+        results,
+        registryState: registry.serialize(),
+      });
+    }
   });
-
-  parentPort?.postMessage(result);
-});
+}


### PR DESCRIPTION
- Added `ObfuscatedFilesRegistry` class to manage obfuscated files.
- Updated `WorkerMessage` and `WorkerResponse` interfaces to include `registryState`.
- Modified `obfuscateBundle` and `obfuscateLibBundle` functions to utilize the registry for tracking obfuscated files.
- Enhanced worker communication to include the registry state for better synchronization.
- Improved `isFileNameExcluded` function to handle both array and single exclude patterns.

## Summary by Sourcery

Enhance the obfuscation pipeline with a centralized registry for file tracking, synchronized state between main and worker threads, and more flexible exclusion handling

New Features:
- Introduce ObfuscatedFilesRegistry singleton to track and persist obfuscated files
- Integrate registry into obfuscateBundle, obfuscateLibBundle, and worker tasks to skip duplicate obfuscation

Enhancements:
- Extend worker messaging protocol to include registryState for bidirectional synchronization
- Enhance isFileNameExcluded to support both single patterns and arrays