### PR TITLE
feat: bump version to 1.8.0 and add nuxt keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "vite-plugin-bundle-obfuscator",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "JavaScript obfuscator plugin for Vite environments",
   "keywords": [
     "vite",
     "vite-rolldown",
+    "nuxt",
     "obfuscator",
     "vite-plugin-obfuscator",
     "vite-bundle-obfuscator",


### PR DESCRIPTION
## Summary by Sourcery

Bump package version to 1.8.0 and include “nuxt” in the npm package keywords

Enhancements:
- Add “nuxt” keyword to package.json keywords

Chores:
- Increment version in package.json to 1.8.0