### PR TITLE
build(workflow): update coverage reporting tool and clean up permissi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write  # 用于 PR 评论（如测试覆盖率报告）
+  pull-requests: write
 
 jobs:
   lint:
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.node-version == '20'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
…on comments

Bumped codecov action from previous major version to latest release. Removed inline documentation for pull request permissions to maintain cleaner workflow configuration.

## Summary by Sourcery

Upgrade the code coverage reporting action to the latest version and streamline the pull-request permissions configuration in the GitHub Actions workflow.

Build:
- Bump codecov-action to v5 in the CI workflow

CI:
- Remove inline comments on pull-request permissions in the CI workflow