### PR TITLE
feat: add support for Laravel projects

### DIFF
--- a/src/__tests__/plugin.spec.ts
+++ b/src/__tests__/plugin.spec.ts
@@ -35,7 +35,8 @@ import {
   isRegExp,
   isString,
   isObject,
-  isBoolean
+  isBoolean,
+  isLaravelProject
 } from '../utils/is';
 import {Worker} from 'node:worker_threads';
 import {encode} from '@jridgewell/sourcemap-codec';
@@ -641,6 +642,36 @@ describe('is utils - additional tests', () => {
 
     it('should return true when nuxt plugin is present', () => {
       expect(isNuxtProject({ plugins: [{ name: 'nuxt:config' }] } as any)).toBe(true);
+    });
+  });
+
+  describe('isLaravelProject', () => {
+    const mkTmp = () => mkdtempSync(join(tmpdir(), 'vite-bundle-obfuscator-'));
+
+    const writePackageJson = (root: string, pkg: any) => {
+      writeFileSync(join(root, 'package.json'), JSON.stringify(pkg), 'utf-8');
+    };
+
+    it('should return false for non-laravel project', () => {
+      expect(isLaravelProject({root: process.cwd()})).toBe(false);
+    });
+
+    it('should use process.cwd() when root is not provided', () => {
+      expect(isLaravelProject({})).toBe(false);
+    });
+
+    it('should return true when package.json depends on laravel', () => {
+      const root = mkTmp();
+      try {
+        writePackageJson(root, { dependencies: { 'laravel-vite-plugin': '^3.0.0' } });
+        expect(isLaravelProject({root})).toBe(true);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('should return true when laravel plugin is present', () => {
+      expect(isLaravelProject({ plugins: [{ name: 'laravel' }] } as any)).toBe(true);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
   obfuscateBundle,
   obfuscateLibBundle,
 } from './utils';
-import { isArray, isFunction, isLibMode, isNuxtProject, isObject } from './utils/is';
+import { isArray, isFunction, isLaravelProject, isLibMode, isNuxtProject, isObject } from './utils/is';
 import { defaultConfig, LOG_COLOR, NODE_MODULES, VENDOR_MODULES } from './utils/constants';
 
 export default function viteBundleObfuscator(config?: Partial<Config>): PluginOption {
@@ -27,6 +27,7 @@ export default function viteBundleObfuscator(config?: Partial<Config>): PluginOp
   const _log = new Log(finalConfig.log);
   let _isLibMode = false;
   let _isNuxtProject = false;
+  let _isLaravelProject = false;
   let _isSsrBuild = false;
 
   const obfuscateAllChunks = async (
@@ -66,6 +67,7 @@ export default function viteBundleObfuscator(config?: Partial<Config>): PluginOp
     _isSsrBuild = !!env.isSsrBuild;
     _isLibMode = isLibMode(config);
     _isNuxtProject = isNuxtProject(config);
+    _isLaravelProject = isLaravelProject(config);
 
     if (finalConfig.enable && isEnabledFeature(finalConfig.obfuscateWorker)) {
       const original = config.worker?.plugins;
@@ -190,7 +192,8 @@ export default function viteBundleObfuscator(config?: Partial<Config>): PluginOp
   };
 
   const generateBundleHandler: Rollup.Plugin['generateBundle'] = async (_, bundle) => {
-    if (!finalConfig.enable || !bundle || _isLibMode || !_isNuxtProject || _isSsrBuild) return;
+    if (!finalConfig.enable || !bundle || _isLibMode || _isSsrBuild) return;
+    if (!_isNuxtProject && !_isLaravelProject) return;
     await obfuscateAllChunks(bundle);
   };
 

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -108,3 +108,35 @@ export function isNuxtProject(config: { root?: string; plugins?: any } = {}): bo
 
   return false;
 }
+
+function hasLaravelDependency(packageJsonPath: string): boolean {
+  if (!existsSync(packageJsonPath)) return false;
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    const dependencies = { ...packageJson.dependencies, ...packageJson.devDependencies };
+    return !!dependencies?.['laravel-vite-plugin'];
+  } catch {
+    return false;
+  }
+}
+
+function hasLaravelPlugins(config: any): boolean {
+  const plugins = config?.plugins;
+  if (!Array.isArray(plugins)) return false;
+  return plugins.some(p => typeof p?.name === 'string' && (p.name === 'laravel' || p.name.startsWith('laravel:')));
+}
+
+export function isLaravelProject(config: { root?: string; plugins?: any } = {}): boolean {
+  if (hasLaravelPlugins(config)) return true;
+
+  const startDir = config.root || process.cwd();
+
+  for (const dir of walkUpDirs(startDir)) {
+    const packageJsonPath = resolve(dir, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      return hasLaravelDependency(packageJsonPath);
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Add support for Laravel (laravel-vite-plugin) projects. A very minimal approach to ensure it doesn't break nor deviate from the original codebase.

This PR follows the same specifications as the Nuxt check:

1. `isLaravelProject` will determine if the project has the `laravel-vite-plugin`.
2. `generateBundleHandler` is extended to check of `isLaravelProject`.

The easiest way to test this is by creating a new Laravel Starter Kit (React/Vue/Svelte) (https://laravel.com/docs/13.x/starter-kits). I tested with the React starter kit.

With this patch, the plugin works perfectly fine by default. No extra configuration required.

```
# vite.config.ts

export default defineConfig({
    plugins: [
        laravel({
            input: ['resources/css/app.css', 'resources/js/app.tsx'],
            refresh: true,
            fonts: [
                bunny('Instrument Sans', {
                    weights: [400, 500, 600],
                }),
            ],
        }),
        inertia(),
        react({
            babel: {
                plugins: ['babel-plugin-react-compiler'],
            },
        }),
        tailwindcss(),
        wayfinder({
            formVariants: true,
        }),
        vitePluginBundleObfuscator(),
    ],
});
```

If there's anything wrong or improvements to be made, please let me know.

## Summary by Sourcery

Add Laravel project detection and enable bundle obfuscation for Laravel Vite setups alongside existing Nuxt support.

New Features:
- Detect Laravel projects via laravel-vite-plugin presence in Vite config or package.json and treat them as eligible for bundle obfuscation.

Tests:
- Add unit tests covering Laravel project detection via plugins, package.json dependencies, and default root resolution behavior.